### PR TITLE
Publish ewf npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Publish
 
 on:
   push:
-    branches: [master, add_energyweb-and-volta-network]
+    branches: [master, publish_ewf_npm]
 
 jobs:
   cancel-previous:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: Set npm credentials
         run: |
-          npm config set registry http://registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
           npm whoami
-        # echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
 
       - name: Publish package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
 
       - name: Publish package
         run: |
-          npm publish
+          npm publish --access=public
           npm push --tags
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     needs: cancel-previous
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.SECRET_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "16.10.0"
@@ -34,4 +34,6 @@ jobs:
         run: |
           npm publish
           npm push --tags
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Set npm credentials
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
+        run: |
+          npm config set registry http://registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          npm whoami
+        # echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
 
       - name: Publish package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set npm credentials & Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
-          npm publish
+          npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,10 @@ jobs:
           node-version: "16.10.0"
           registry-url: https://registry.npmjs.org/
 
-      - name: Set npm credentials
+      - name: Set npm credentials & Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm whoami
-
-      - name: Publish package
-        run: |
+          cat $HOME/.npmrc
           npm publish --access=public
           npm push --tags
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Set npm credentials & Publish
         run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm publish --access=public
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
+          npm publish
           npm push --tags
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set npm credentials
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
+          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm whoami
 
       - name: Publish package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
           npm publish
-          npm push --tags
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cancel-previous:
-    name: "Cancel Previous Runs"
+    name: Cancel Previous Runs
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: "16.10.0"
+          node-version: 16.10.0
           registry-url: https://registry.npmjs.org/
 
       - name: Set npm credentials & Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master, add_energyweb-and-volta-network]
+
+jobs:
+  cancel-previous:
+    name: "Cancel Previous Runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: cancel-previous
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SECRET_NAME }}
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "16.10.0"
+          registry-url: https://registry.npmjs.org/
+
+      - name: Set npm credentials
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> $HOME/.npmrc
+
+      - name: Publish package
+        run: |
+          npm publish
+          npm push --tags
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Publish
+name: Release
 
 on:
   push:
-    branches: [master, publish_ewf_npm]
+    branches: [release]
 
 jobs:
   cancel-previous:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Set npm credentials & Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          cat $HOME/.npmrc
           npm publish --access=public
           npm push --tags
         env:

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The Graph CLI can be installed with `npm` or `yarn`:
 
 ```sh
 # NPM
-npm install -g @graphprotocol/ew-graph-cli
+npm install -g @energyweb/ew-graph-cli
 
 # Yarn
-yarn global add @graphprotocol/ew-graph-cli
+yarn global add @energyweb/ew-graph-cli
 ```
 
 ### On Linux

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@graphprotocol/graph-cli.svg)](https://www.npmjs.com/package/@graphprotocol/graph-cli)
 [![Build Status](https://travis-ci.org/graphprotocol/graph-cli.svg?branch=master)](https://travis-ci.org/graphprotocol/graph-cli)
 
-## ***This is a fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add `Energyweb` & `Volta` network in the `graph-cli` CLI. This `graph-cli` will allow you to choose `energyweb` & `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.***
+*This is fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add `Energyweb` & `Volta` network in the `graph-cli` CLI. This `@energyweb/graph-cli` will allow you to choose `energyweb` or `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.*
 
 ## The Graph Command Line Interface
 
@@ -35,10 +35,10 @@ The Graph CLI can be installed with `npm` or `yarn`:
 
 ```sh
 # NPM
-npm install -g @energyweb/ew-graph-cli
+npm install -g @energyweb/graph-cli
 
 # Yarn
-yarn global add @energyweb/ew-graph-cli
+yarn global add @energyweb/graph-cli
 ```
 
 ### On Linux

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@graphprotocol/graph-cli.svg)](https://www.npmjs.com/package/@graphprotocol/graph-cli)
 [![Build Status](https://travis-ci.org/graphprotocol/graph-cli.svg?branch=master)](https://travis-ci.org/graphprotocol/graph-cli)
 
-*This is fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add `Energyweb` & `Volta` network in the `graph-cli` CLI. This `@energyweb/graph-cli` will allow you to choose `energyweb` or `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.*
+*This is fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add `Energyweb` & `Volta` network in the `graph-cli` CLI. This [@energyweb/graph-cli](https://github.com/energywebfoundation/graph-cli) will allow user to choose `energyweb` or `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.*
 
 ## The Graph Command Line Interface
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@graphprotocol/graph-cli.svg)](https://www.npmjs.com/package/@graphprotocol/graph-cli)
 [![Build Status](https://travis-ci.org/graphprotocol/graph-cli.svg?branch=master)](https://travis-ci.org/graphprotocol/graph-cli)
 
+## ***This is a fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add `Energyweb` & `Volta` network in the `graph-cli` CLI. This `graph-cli` will allow you to choose `energyweb` & `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.***
+
 ## The Graph Command Line Interface
 
 As of today, the command line interface supports the following commands:
@@ -33,10 +35,10 @@ The Graph CLI can be installed with `npm` or `yarn`:
 
 ```sh
 # NPM
-npm install -g @graphprotocol/graph-cli
+npm install -g @graphprotocol/ew-graph-cli
 
 # Yarn
-yarn global add @graphprotocol/graph-cli
+yarn global add @graphprotocol/ew-graph-cli
 ```
 
 ### On Linux
@@ -76,6 +78,7 @@ Current version: `0.34.9`.
 Desired release: `0.35.0`.
 
 To create the PR:
+
 ```
 git checkout -b <BRANCH>
 
@@ -98,6 +101,7 @@ Current version: `0.29.2`.
 Desired release: `0.30.0-alpha.0`.
 
 To create the PR:
+
 ```
 git checkout -b <BRANCH>
 
@@ -120,6 +124,7 @@ Current version: `0.30.0-alpha.0`.
 Desired release: `0.30.0-alpha.1`.
 
 To create the PR:
+
 ```
 git checkout -b <BRANCH>
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@graphprotocol/graph-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/energywebfoundation/graph-cli.git"
+  },
+  "homepage": "https://github.com/energywebfoundation/graph-cli.git#readme",
   "version": "0.27.0",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graphprotocol/graph-cli",
+  "name": "graph-cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/energywebfoundation/graph-cli.git"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graph-cli",
+  "name": "ewf-graph-cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/energywebfoundation/graph-cli.git"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ewf-graph-cli",
+  "name": "@graphprotocol/ew-graph-cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/energywebfoundation/graph-cli.git"
   },
   "homepage": "https://github.com/energywebfoundation/graph-cli.git#readme",
-  "version": "0.27.0",
+  "version": "0.26.0",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graphprotocol/ew-graph-cli",
+  "name": "@energyweb/ew-graph-cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/energywebfoundation/graph-cli.git"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@energyweb/ew-graph-cli",
+  "name": "@energyweb/graph-cli",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/energywebfoundation/graph-cli.git"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -132,7 +132,7 @@ const processInitForm = async (
           return `${e.message}
 
   Examples:
-  
+
     $ graph init ${os.userInfo().username}/${name}
     $ graph init ${name} --allow-simple-name`
         }
@@ -283,9 +283,11 @@ const getEtherscanLikeAPIUrl = (network) => {
     case "bsc": return `https://api.bscscan.com/api`;
     case "matic": return `https://api.polygonscan.com/api`;
     case "mumbai": return `https://api-testnet.polygonscan.com/api`;
+    case "energyweb": return `https://explorer.energyweb.org/api`;
+    case "volta": return `https://volta-explorer.energyweb.org/api`;
     default: return `https://api-${network}.etherscan.io/api`;
   }
-} 
+}
 
 const loadAbiFromEtherscan = async (ABI, network, address) =>
   await withSpinner(
@@ -353,7 +355,7 @@ module.exports = {
 
     node = node || g
     ;({ node, allowSimpleName } = chooseNodeUrl({ product, studio, node, allowSimpleName }))
-    
+
     if (fromContract && fromExample) {
       print.error(`Only one of --from-example and --from-contract can be used at a time.`)
       process.exitCode = 1

--- a/src/protocols/index.js
+++ b/src/protocols/index.js
@@ -59,6 +59,8 @@ module.exports = class Protocol {
         'optimism-kovan',
         'aurora',
         'aurora-testnet',
+        'energyweb',
+        'volta',
       ],
       near: [
         'near-mainnet',


### PR DESCRIPTION
This is fork from [@graphprotocol/graph-cli](https://github.com/graphprotocol/graph-cli.git) to add Energyweb & Volta network in the graph-cli CLI. 
This [@energyweb/graph-cli](https://github.com/energywebfoundation/graph-cli) will allow user to choose `energyweb` or `volta` network and download the ABI of the provided smart contract from `Energyweb` & `Volta` network.